### PR TITLE
Forward compatibility with voryx/event-loop 3.0 and while supporting 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "react/socket": "^0.8.9",
         "reactivex/rxphp": "^2.0",
-        "voryx/event-loop": "^2.0"
+        "voryx/event-loop": "^3.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b217a4ac6d9fbc17bee047fc6402591",
+    "content-hash": "7cba24ba13923e0912e8d26b5c962d98",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -436,20 +436,23 @@
         },
         {
             "name": "voryx/event-loop",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voryx/event-loop.git",
-                "reference": "4cd6bc28465303bf6da63202201463e420d4ec79"
+                "reference": "ed7ee6236945b64591f8ef2be855e6244f1439e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voryx/event-loop/zipball/4cd6bc28465303bf6da63202201463e420d4ec79",
-                "reference": "4cd6bc28465303bf6da63202201463e420d4ec79",
+                "url": "https://api.github.com/repos/voryx/event-loop/zipball/ed7ee6236945b64591f8ef2be855e6244f1439e6",
+                "reference": "ed7ee6236945b64591f8ef2be855e6244f1439e6",
                 "shasum": ""
             },
             "require": {
-                "react/event-loop": "^0.4.2"
+                "react/event-loop": "^1.0 || ^0.5 || ^0.4.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6"
             },
             "type": "library",
             "autoload": {
@@ -485,7 +488,7 @@
                 "static",
                 "timer"
             ],
-            "time": "2017-03-14T01:10:32+00:00"
+            "time": "2018-04-18T00:07:06+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
`voryx/event-loop` just released a new version which supports `react/event-loop` [`0.5`](https://github.com/reactphp/event-loop/releases/tag/v0.5.0). This PR bring support for those new event loop versions while still supporting the current ones targeted by this package.